### PR TITLE
feat: CLIN-5357 relax metric order assumptions in format column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+## [v1.1.2] - 2025-11-18
+
+### `Changed`
+- [#2](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering-parental-origin/pull/1) call sample_preprocessing.py script via module b
+
+## [v1.1.1] - 2024-10-10
+
+### `Changed`
+
+- [#1](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering-parental-origin/pull/1) call sample_preprocessing.py script via module binaries feature
+
+
 ## [v1.1] - 2024-08-21
 
 ### `Added`

--- a/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
+++ b/modules/local/preprocessing/resources/usr/bin/sample_preprocessing.py
@@ -8,6 +8,8 @@ import sys
 
 VERSION = "1.0"
 
+FORMAT_COLUMN_IDX = 8 # 0-based index of the FORMAT column in VCF
+
 def create_ploidy_table(samples):
     """
     Creates a ploidy table with chromosome names and sample IDs.
@@ -41,15 +43,32 @@ def process_vcf(sample_id, vcf_path):
     # Modify the VCF content
     with gzip.open(input_vcf, 'rt') if input_vcf.endswith('.gz') else open(input_vcf, 'r') as infile, open(mod_vcf, 'w') as outfile:
         for line in infile:
-            if line.startswith("##FORMAT=<ID=CN,Number=1,Type=Integer,Description=\"Estimated copy number\">"):
+            if line.startswith("##FORMAT=<ID=PE,"):
                 outfile.write(line)
                 outfile.write("##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">\n")
                 continue
             elif not line.startswith("#"):
+                # Insert INFO field ALGORITHMS
                 line = re.sub(r";END", ";ALGORITHMS=depth;END", line)
-                line = re.sub(r":PE", ":PE:ECN", line)
-                line = line.strip() + ":2\n"
+
+                # Insert ECN just after PE in FORMAT column
+                cols = line.strip().split('\t')
+                format_col = cols[FORMAT_COLUMN_IDX]
+                format_fields = format_col.split(':')
+                ecn_index = format_fields.index("PE") + 1
+                format_fields.insert(ecn_index, "ECN")
+                cols[FORMAT_COLUMN_IDX] = ':'.join(format_fields)
+
+                # Insert ECN metric just after PE metric in each sample column
+                # Just in case, supporting multi-sample, but our use case is single-sample VCFs
+                for i in range(FORMAT_COLUMN_IDX + 1, len(cols)):
+                    sample_values = cols[i].split(':')
+                    sample_values.insert(ecn_index, "2")
+                    cols[i] = ':'.join(sample_values)
+                
+                line = '\t'.join(cols) + '\n'
             outfile.write(line)
+
 
     # Extract DUP and DEL variants
     extract_variants(mod_vcf, dup_vcf, "DUP")

--- a/nextflow.config
+++ b/nextflow.config
@@ -213,7 +213,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.1'
+    version         = '1.1.2'
     doi             = ''
 }
 


### PR DESCRIPTION
Dragen 4.4 VCFs include the PE metric in the FORMAT column, but not necessarily at the end as previously assumed.

This PR relaxes the rigid assumption about the position of PE in the FORMAT and sample columns, ensuring compatibility with Dragen 4.4 VCFs.

DRAFT MODE:
We are missing:
- local tests
- integration test
- doc / bump version / changelog 