### PR TITLE
Feat/clin 5347 add output options and correct output filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.1.3] - 2025-11-25
+
+### `Added`
+- [#3](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering-parental-origin/pull/3) add extra parameters dup_outdir and del_outdir to customize output folders for dup and del clusters
+
+### `Changed`
+- [#3](https://github.com/Ferlab-Ste-Justine/ferlab-svclustering-parental-origin/pull/3) output filenames now dynamically reflect the clustering algorithm and reciprocal overlap threshold
+
+
 ## [v1.1.2] - 2025-11-18
 
 ### `Changed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,4 +18,19 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
+    withName: SVCLUSTERINGDUP {
+        publishDir = [
+            path: { params.dup_outdir ?: "${params.outdir}/svclusteringdup" },
+            pattern: '*{vcf,vcf.gz,vcf.gz.tbi}',
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: SVCLUSTERINGDEL {
+        publishDir = [
+            path: { params.del_outdir ?: "${params.outdir}/svclusteringdel" },
+            pattern: '*{vcf,vcf.gz,vcf.gz.tbi}',
+            mode: params.publish_dir_mode
+        ]
+    }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -23,10 +23,23 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
     - ${sample}.cnv.mod.(DEL/DUP).bed
     - ploidy_table.tsv
   - `svclusteringdup/`
-    - ${familyId}.MAX_CLIQUE_RO80.DUP.vcf : The vcf with CNV DUP cluster per family
+    - ${familyId}.SINGLE_LINKAGE_RO80.DUP.vcf.gz : The vcf with CNV DUP cluster per family
   - `svclusteringdel/`
-    - ${familyId}.MAX_CLIQUE_RO80.DEL.vcf : The vcf with CNV DEL cluster per family
+    - ${familyId}.SINGLE_LINKAGE_RO80.DEL.vcf.gz : The vcf with CNV DEL cluster per family
 
 </details>
 
 [Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.
+
+### Customize the output folders
+
+By default, the main output files (DUP clusters and DEL clusters) are saved in the main output directory specified by the `outdir` parameter, within a subfolder named after the process that generated them (see Pipeline Information above).
+
+If you prefer, you can set custom output directories for these files using the `dup_outdir` and `del_outdir` configuration parameters.
+
+Regardless of the output directory chosen, the filenames for these cluster files will follow this pattern: 
+"`${familyId}`.`${clustering_algorithm}`_RO`${reciprocal_overlap_in_percent}`.`${variant_type}`.vcf.gz"
+
+For example:
+- `123.SINGLE_LINKAGE_RO80.DEL.vcf.gz`
+- `123.SINGLE_LINKAGE_RO80.DUP.vcf.gz`

--- a/modules/local/svclustering/svclusteringdel.nf
+++ b/modules/local/svclustering/svclusteringdel.nf
@@ -24,8 +24,9 @@ process SVCLUSTERINGDEL {
     def clustering_algorithm = params.clustering_algorithm
     def overlap              = params.overlap
     def breakpoint_strategy  = params.breakpoint_strategy
+    def output_file          = "${familyId}.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DEL.vcf.gz"
     """
-    gatk SVCluster --output ${familyId}.MAX_CLIQUE_RO80.DEL.vcf.gz -V $dels \
+    gatk SVCluster --output ${output_file} -V $dels \
      --ploidy-table $ploidy --algorithm $clustering_algorithm \
      --reference $fasta --depth-interval-overlap $overlap \
      --breakpoint-summary-strategy $breakpoint_strategy \

--- a/modules/local/svclustering/svclusteringdup.nf
+++ b/modules/local/svclustering/svclusteringdup.nf
@@ -24,8 +24,9 @@ process SVCLUSTERINGDUP {
     def clustering_algorithm = params.clustering_algorithm
     def overlap              = params.overlap
     def breakpoint_strategy  = params.breakpoint_strategy
+    def output_file          = "${familyId}.${clustering_algorithm.toUpperCase()}_RO${Math.round(overlap * 100)}.DUP.vcf.gz"
     """
-    gatk SVCluster --output ${familyId}.MAX_CLIQUE_RO80.DUP.vcf.gz -V $dups \
+    gatk SVCluster --output ${output_file} -V $dups \
      --ploidy-table $ploidy --algorithm $clustering_algorithm \
      --reference $fasta --depth-interval-overlap $overlap \
      --breakpoint-summary-strategy $breakpoint_strategy \

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,6 +25,10 @@ params {
     fasta_dict                   = null
     enable_conda                 = true
 
+    // Extra output options
+    dup_outdir                   = null
+    del_outdir                   = null
+
     //clustering options
     clustering_algorithm          = 'SINGLE_LINKAGE'
     overlap                       =  0.8
@@ -213,7 +217,7 @@ manifest {
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.1.2'
+    version         = '1.1.3'
     doi             = ''
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -28,6 +28,18 @@
           "format": "directory-path",
           "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
           "fa_icon": "fas fa-folder-open"
+        },
+        "dup_outdir": {
+          "type": "string",
+          "description": "When specified, publishes the DUP cluster files in this directory",
+          "format": "directory-path",
+          "fa_icon": "fas fa-folder-open"
+        },
+        "del_outdir": {
+          "type": "string",
+          "description": "When specified, publishes the DEL cluster files in this directory",
+          "format": "directory-path",
+          "fa_icon": "fas fa-folder-open"
         }
       }
     },

--- a/workflows/svclusteringpo.nf
+++ b/workflows/svclusteringpo.nf
@@ -59,18 +59,18 @@ workflow SVCLUSTERINGPO {
     SVCLUSTERINGDUP(
         vcfdup, 
         ploidy,
-        params.fasta,
-        params.fasta_fai,
-        params.fasta_dict,
+        file(params.fasta),
+        file(params.fasta_fai),
+        file(params.fasta_dict),
         )
     ch_versions = ch_versions.mix(SVCLUSTERINGDUP.out.versions)
 
     SVCLUSTERINGDEL(
         vcfdel, 
         ploidy,
-        params.fasta,
-        params.fasta_fai,
-        params.fasta_dict,
+        file(params.fasta),
+        file(params.fasta_fai),
+        file(params.fasta_dict),
         )
     ch_versions = ch_versions.mix(SVCLUSTERINGDEL.out.versions)
     


### PR DESCRIPTION
# CLIN-5347 Add extra output options and correct output filename

## 📌 Context

This PR introduces additional output options to allow specifying separate folders for DUP and DEL cluster files, aligning with output conventions used in other Nextflow pipelines in clin. These parameters are optional; if not provided, outputs default to the main outdir folder.

We also update the cluster output filenames to dynamically reflect the configured clustering algorithm and reciprocal overlap threshold, ensuring filenames match the actual parameters used rather than being hardcoded.

## 📝 Changes

- Added two new output parameters: dup_outdir and del_outdir (schema  + nextflow.config)
- Updated SVCLUSTERINGDUP and SVCLUSTERINGDEL publish directory configuration to use these new parameters
- Update output documentation
- Output filenames now dynamically reflect the clustering algorithm and reciprocal overlap threshold
- Other Minor change: switched to using file objects instead of strings for reference file paths to support local relative URLs
- Bump version and update changelog

## 🧪 Tests

Local tests were performed using a small public dataset with various parameter combinations:
- `--outdir=results`
- `--outdir=results --dup_outdir=foo`
- `--outdir=results --del_outdir=foo`
- `--outdir=results --dup_outdir=foo --del_outdir=bar`
- `--outdir=results --dup_outdir=foo --del_outdir=foo`
- `--outdir=results --clustering_algorithm=MAX_CLIQUE --overlap=0.9`

Verified that output files and folders match documentation expectations.

For `--outdir=results`, also compared output files (DUP/DEL clusters) with those from the clin branch to confirm they are identical.

Tested error handling: running with `--dup_outdir=foo --del_outdir=bar` without `--outdir` correctly raises an error.

Check that there are no new linter warning in comparison to the clin branch

Integration test performed in qlin: OK

## 🔗 Related Issues

- https://ferlab-crsj.atlassian.net/browse/CLIN-5347
